### PR TITLE
Sort stations by name instead of by key

### DIFF
--- a/src/Stations.elm
+++ b/src/Stations.elm
@@ -14,6 +14,7 @@ all =
         |> List.concat
         |> Dict.fromList
         |> Dict.toList
+        |> List.sortBy Tuple.second
 
 
 findName : String -> Maybe String
@@ -40,6 +41,7 @@ matching abbreviation =
         |> Dict.fromList
         |> Dict.remove abbreviation
         |> Dict.toList
+        |> List.sortBy Tuple.second
 
 
 commuterStations : List StationList


### PR DESCRIPTION
Without this, ("HKH", "Hiekkaharju") is listed before ("HKI", "Helsinki"), which is confusing to the user.