### PR TITLE
Alternative layout

### DIFF
--- a/src/Translations.elm
+++ b/src/Translations.elm
@@ -63,7 +63,7 @@ type TranslationKey
     | ErrorBadStatus
     | ErrorBadPayload
     | SchedulePageLoading
-    | SchedulePageJourneyDuration { durationMinutes : Int, stopsBetween : Int }
+    | SchedulePageJourneyDuration { durationMinutes : Int, slowerBy : Int, fastestName : String }
     | SchedulePageArrivesIn
     | SchedulePageDepartsIn
     | SchedulePageTimeDifference { minuteDiff : Int, stationName : String }
@@ -300,45 +300,26 @@ htmlTranslationSetFor key =
             }
 
 
-journeyDurationTranslationSet : { durationMinutes : Int, stopsBetween : Int } -> TranslationSet
-journeyDurationTranslationSet { durationMinutes, stopsBetween } =
-    { english =
-        String.fromInt durationMinutes
-            ++ " min · "
-            ++ (case String.fromInt stopsBetween of
-                    "0" ->
-                        "nonstop"
+journeyDurationTranslationSet : { durationMinutes : Int, slowerBy : Int, fastestName : String } -> TranslationSet
+journeyDurationTranslationSet { durationMinutes, slowerBy, fastestName } =
+    let
+        dMin =
+            String.fromInt durationMinutes ++ " min"
 
-                    "1" ->
-                        "1 stop"
+        slowerPrefix =
+            dMin ++ " · " ++ String.fromInt slowerBy ++ " min "
+    in
+    if slowerBy < 4 then
+        { english = dMin ++ " · fast"
+        , finnish = dMin ++ " · nopea"
+        , swedish = dMin ++ " · snabbt"
+        }
 
-                    n ->
-                        n ++ " stops"
-               )
-    , finnish =
-        String.fromInt durationMinutes
-            ++ " min · "
-            ++ (case String.fromInt stopsBetween of
-                    "0" ->
-                        "ei pysähdyksiä"
-
-                    "1" ->
-                        "1 pysähdys"
-
-                    n ->
-                        n ++ " pysähdystä"
-               )
-    , swedish =
-        String.fromInt durationMinutes
-            ++ " min · "
-            ++ (case String.fromInt stopsBetween of
-                    "0" ->
-                        "Utan stopp"
-
-                    n ->
-                        n ++ " stopp"
-               )
-    }
+    else
+        { english = slowerPrefix ++ "slower than " ++ fastestName
+        , finnish = slowerPrefix ++ "hitaampi kuin " ++ fastestName
+        , swedish = slowerPrefix ++ "långsammare än " ++ fastestName
+        }
 
 
 timeDifferenceTranslationSet : { minuteDiff : Int, stationName : String } -> TranslationSet

--- a/src/View.elm
+++ b/src/View.elm
@@ -308,10 +308,9 @@ trainRow t data train =
                     div [ class "train-status-badge is-cancelled" ] [ tText SchedulePageCancelled ]
     in
     div [ class "train" ]
-        [ div [ class "train-content" ]
-            [ div [ classList [ ( "train-name", True ), ( "is-running", train.runningCurrently ) ] ]
-                [ text train.lineId ]
-            , div [ class "train-stations" ]
+        [ metaDataRow t data train
+        , div [ class "train-content" ]
+            [ div [ class "train-stations" ]
                 [ stationRow data.zone data.stations train.homeStationDeparture
                 , div [ class "train-stations-row" ]
                     [ div [ class "train-stations-separator" ]
@@ -351,12 +350,11 @@ trainRow t data train =
                         []
             ]
         , statusInfoBadge
-        , duration t data train
         ]
 
 
-duration : T -> TrainRowData -> Train -> Html msg
-duration t data current =
+metaDataRow : T -> TrainRowData -> Train -> Html msg
+metaDataRow t data current =
     let
         ( fastest, slowest ) =
             data.allTrains
@@ -390,7 +388,14 @@ duration t data current =
             , slowerBy = current.durationMinutes - fastest.durationMinutes
             , fastestName = fastest.lineId
             }
-            |> (\key -> [ span [ class "duration-text-content" ] [ text (t key) ], wagonCount ])
+            |> (\key ->
+                    [ span [ class "duration-text-content" ]
+                        [ strong [] [ text (current.lineId ++ " · ") ]
+                        , text (t key)
+                        ]
+                    , wagonCount
+                    ]
+               )
             |> div [ class "duration-text" ]
         , div [ class "duration-bar" ]
             [ div

--- a/style.css
+++ b/style.css
@@ -27,6 +27,12 @@
   --type-scale-3: 2.369rem;
 }
 
+@media screen and (max-width: 400px) {
+  :root {
+    font-size: 16px;
+  }
+}
+
 html,
 head,
 body {
@@ -120,7 +126,7 @@ a:visited {
 }
 
 .train-content {
-  padding: 1rem;
+  padding: 1rem 1rem 0.5rem;
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
@@ -186,13 +192,14 @@ a:visited {
 
 .train-wagon-count {
   overflow: hidden;
-  height: 18px;
+  height: 1rem;
+  display: inline-block;
 }
 
 .train-wagon-count svg {
   width: 2rem;
   /* counter the spacing in the icon */
-  margin-top: -7px;
+  margin-top: -0.5rem;
 }
 
 .train-stations {
@@ -241,15 +248,34 @@ a:visited {
   font-weight: bold;
 }
 
-.train-stations-duration {
-  color: var(--color-grey);
-  font-size: var(--type-scale--1);
+.duration {
+  padding-top: 2px;
 }
 
-.train-duration-station {
-  height: 100%;
-  width: 2px;
-  background: var(--color-black);
+.duration-text {
+  color: var(--color-grey);
+  font-size: var(--type-scale--1);
+  margin-left: 1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.duration-bar {
+  width: 100%;
+  height: 2px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  background: var(--color-charcoal);
+}
+
+.duration-bar-reference {
+  background: var(--color-grey);
+}
+
+.duration-bar-diff {
+  background: var(--color-slightlyOffSchedule-light);
 }
 
 .trains-end-of-list {

--- a/style.css
+++ b/style.css
@@ -121,8 +121,7 @@ a:visited {
 }
 
 .train {
-  background-color: var(--color-black);
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
 }
 
 .train-content {
@@ -130,6 +129,7 @@ a:visited {
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
+  background-color: var(--color-black);
 }
 
 .train-name {


### PR DESCRIPTION
Moves all the metadata (information not directly related to schedules/timing) to the top of the card. Also includes a visual indicator for the trip duration in relation to the others.

Left: old, right: new
![screenshot from 2019-01-31 09-17-45](https://user-images.githubusercontent.com/8436403/52037932-34c1f200-2539-11e9-8fa9-7caab04a17c4.png)
